### PR TITLE
use accessoryConfig.name

### DIFF
--- a/src/ps4-device.ts
+++ b/src/ps4-device.ts
@@ -69,13 +69,14 @@ function _createDevice(accessoryConfig: AccessoryConfig, globalConfig: GlobalCon
     });
     api.lastInfo = deviceInfoRaw;
     api.lastInfo.address = connectionInfo.address;
+    const deviceInfo = new DeviceInfo(deviceInfoRaw);
     return new PS4Device({
         api: api,
-        info: new DeviceInfo(deviceInfoRaw),
+        info: deviceInfo,
         connectionInfo: connectionInfo,
         apps: _mergeAppConfigs(accessoryConfig.apps, globalConfig.apps),
         serial: accessoryConfig.serial,
-        name: accessoryConfig.name || connectionInfo.host.name,
+        name: accessoryConfig.name || deviceInfo.host.name,
         model: accessoryConfig.model,
         timeout: accessoryConfig.timeout || globalConfig.timeout || 5000
     });


### PR DESCRIPTION
The documentation makes reference to `name` in Accessory Config (https://github.com/bbriatte/homebridge-ps4-waker-platform/blame/master/README.md#L96) however the code did not use it.