### PR TITLE
Support multiple network interfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ Example `config.json` for one PS4 and 2 apps:
 * `pollingInterval`: If set, poll the device each interval
 * `apps`: Contains all apps action that you want to trigger using HomeKit on your device. Adds a switch for each app with the given name. see **App element**
 * `timeout`: Timeout to access to your PS4. **Default: 5000ms**
+* `bindAddress`: IP to bind to if your host has multiple network interfaces
 
 ### Global element
 *Optional fields*
@@ -109,6 +110,7 @@ Example `config.json` for one PS4 and 2 apps:
 * `pollingInterval`: If set, poll the device each interval
 * `apps`: Contains all apps action that you want to trigger using HomeKit on all PS4 device. Adds a switch for each app with the given name. see **App element**
 * `timeout`: Timeout to access all PS4 on your network. **Default: 5000ms**
+* `bindAddress`: IP to bind to if your host has multiple network interfaces
 
  ### App element
  *Required fields*

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Example `config.json` to register 2 PS4
             "serial": "XXXXXXXXXXX",
             "model": "CUH-7016B",
             "ip": "192.168.0.20",
-            "credentials": ".ps4-pro-wake.credentials.json"  
+            "credentials": ".ps4-pro-wake.credentials.json"
         },
         {
           "serial": "XXXXXXXXXXX",
@@ -74,6 +74,23 @@ Example `config.json` for one PS4 and 2 apps:
                     "name": "Fortnite"
                 }
             ]
+        }
+    ]
+}
+```
+
+Example `config.json` if your homebridge has multiple network interfaces. Specify which address to use for `ps4-waker`:
+
+
+```json
+{
+    "platform": "PS4WakerPlatform",
+    "name": "PS4Waker",
+    "accessories": [
+      {
+            "serial": "XXXXXXXXXXX",
+            "model": "CUH-7016B",
+            "bindAddress": "192.16.1.2"
         }
     ]
 }

--- a/src/accessory-config.ts
+++ b/src/accessory-config.ts
@@ -4,6 +4,7 @@ export interface GlobalConfig extends BaseGlobalConfig {
     readonly apps?: AppConfig[];
     readonly pollingInterval?: number;
     timeout?: number;
+    bindAddress?: string; // if you have multiple network interfaces
 }
 
 export interface AccessoryConfig extends GlobalConfig {
@@ -11,6 +12,7 @@ export interface AccessoryConfig extends GlobalConfig {
     model: string;
     name?: string;
     ip?: string; // if you have more than one ps4 on your network
+    bindAddress?: string; // if you have multiple network interfaces
     passCode?: string;
     credentials?: string;
 }

--- a/src/ps4-device.ts
+++ b/src/ps4-device.ts
@@ -58,6 +58,7 @@ export async function deviceFromConfig(accessoryConfig: AccessoryConfig, globalC
         Detector.findWhen((deviceInfoRaw: any, connectionInfo: ConnectionInfo) => {
             return accessoryConfig.ip === undefined || connectionInfo.address === accessoryConfig.ip
         }, {
+            bindAddress: accessoryConfig.bindAddress || globalConfig.bindAddress,
             timeout: accessoryConfig.timeout || globalConfig.timeout || 5000
         }, (err, deviceInfoRaw: any, connectionInfo: ConnectionInfo) => {
             if(err) {
@@ -74,7 +75,8 @@ function _createDevice(accessoryConfig: AccessoryConfig, globalConfig: GlobalCon
         address: connectionInfo.address,
         autoLogin: true,
         credentials: accessoryConfig.credentials,
-        passCode: accessoryConfig.passCode
+        passCode: accessoryConfig.passCode,
+        bindAddress: accessoryConfig.bindAddress || globalConfig.bindAddress,
     });
     api.lastInfo = deviceInfoRaw;
     api.lastInfo.address = connectionInfo.address;


### PR DESCRIPTION
ps4-waker has a bindAddress property that you can specify to tell the plugin which network interface to use. Otherwise it will use the default one which might not be able to connect to the ps4 if you have multiple VLANs for example.

I wasn't able to test this properly, is there some guide how to test this in an easy way? I just tested in my setup that the ps4-waker was able to start my playstation properly when setting this property.